### PR TITLE
Manifest for upload service

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,4 @@ TODO:
   - Inference using a 6000x8000 image (image to be posted by a phone) takes ~100s with 5 CPU and 12Gi memory
   - When CPU is set to 1, durations are ~2.5x longer
   - When TensorFlow Serving is used in a Docker container, durations are much shorter (no memory/CPU limit)
+- Use secrets for credentials in general

--- a/infra/openshift-manifests/kustomization.yaml
+++ b/infra/openshift-manifests/kustomization.yaml
@@ -14,4 +14,5 @@ resources:
   - minio-tenant.yaml
   - ai-demo-namespace.yaml
   - minio-webhook-source/service.yaml
+  - upload-service/service.yaml
 

--- a/infra/openshift-manifests/upload-service/service.yaml
+++ b/infra/openshift-manifests/upload-service/service.yaml
@@ -1,0 +1,54 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: upload-service
+  namespace: ai-demo
+spec:
+  selector:
+    app: upload-service
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 5000
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: upload-service
+  namespace: ai-demo
+  labels:
+    app: upload-service
+spec:
+  containers:
+    - name: upload-service
+      image: docker.io/aliok/upload-service:latest
+      imagePullPolicy: Always
+      ports:
+        - containerPort: 5000
+      env:
+        - name: S3_ENDPOINT_URL
+          value: https://minio.minio-operator.svc.cluster.local
+        - name: S3_ACCESS_KEY_ID
+          value: minio
+        - name: S3_ACCESS_KEY_SECRET
+          value: minio1234
+        - name: S3_ACCESS_SSL_VERIFY
+          value: "false"
+        - name: S3_BUCKET_NAME
+          value: ai-demo
+---
+kind: Route
+apiVersion: route.openshift.io/v1
+metadata:
+  name: upload-service
+  namespace: ai-demo
+spec:
+  to:
+    kind: Service
+    name: upload-service
+  port:
+    targetPort: 5000
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: None
+  wildcardPolicy: None

--- a/infra/openshift-manifests/upload-service/service.yaml
+++ b/infra/openshift-manifests/upload-service/service.yaml
@@ -1,54 +1,22 @@
-apiVersion: v1
+apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
   name: upload-service
   namespace: ai-demo
 spec:
-  selector:
-    app: upload-service
-  ports:
-    - protocol: TCP
-      port: 80
-      targetPort: 5000
----
-apiVersion: v1
-kind: Pod
-metadata:
-  name: upload-service
-  namespace: ai-demo
-  labels:
-    app: upload-service
-spec:
-  containers:
-    - name: upload-service
-      image: docker.io/aliok/upload-service:latest
-      imagePullPolicy: Always
-      ports:
-        - containerPort: 5000
-      env:
-        - name: S3_ENDPOINT_URL
-          value: https://minio.minio-operator.svc.cluster.local
-        - name: S3_ACCESS_KEY_ID
-          value: minio
-        - name: S3_ACCESS_KEY_SECRET
-          value: minio1234
-        - name: S3_ACCESS_SSL_VERIFY
-          value: "false"
-        - name: S3_BUCKET_NAME
-          value: ai-demo
----
-kind: Route
-apiVersion: route.openshift.io/v1
-metadata:
-  name: upload-service
-  namespace: ai-demo
-spec:
-  to:
-    kind: Service
-    name: upload-service
-  port:
-    targetPort: 5000
-  tls:
-    termination: edge
-    insecureEdgeTerminationPolicy: None
-  wildcardPolicy: None
+  template:
+    spec:
+      containers:
+        - image: docker.io/aliok/upload-service:latest
+          imagePullPolicy: Always
+          env:
+            - name: S3_ENDPOINT_URL
+              value: https://minio.minio-operator.svc.cluster.local
+            - name: S3_ACCESS_KEY_ID
+              value: minio
+            - name: S3_ACCESS_KEY_SECRET
+              value: minio1234
+            - name: S3_ACCESS_SSL_VERIFY
+              value: "false"
+            - name: S3_BUCKET_NAME
+              value: ai-demo

--- a/services/upload-service/Dockerfile
+++ b/services/upload-service/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9
+FROM python:3.9-slim
 
 COPY requirements.txt /opt/app/requirements.txt
 
@@ -18,5 +18,11 @@ ENV MAX_IMG_HEIGHT=640
 ENV S3_BUCKET_NAME='ai-demo'
 ENV S3_ACCESS_SSL_VERIFY='true'
 
-CMD ["flask", "--app", "main", "run", "--host", "0.0.0.0"]
+ENV PORT=8080
+ENV WORKERS=1
+ENV THREADS=8
+ENV TIMEOUT=0
+
+CMD exec gunicorn --bind :$PORT --workers $WORKERS --threads $THREADS --timeout $TIMEOUT app:app
+
 

--- a/services/upload-service/Dockerfile
+++ b/services/upload-service/Dockerfile
@@ -15,7 +15,7 @@ ENV MAX_IMG_SIZE_IN_BYTES=1000000
 ENV MAX_IMG_WIDTH=640
 ENV MAX_IMG_HEIGHT=640
 
-ENV S3_BUCKET_NAME='knative-eventing-ai-demo-uploads'
+ENV S3_BUCKET_NAME='ai-demo'
 ENV S3_ACCESS_SSL_VERIFY='true'
 
 CMD ["flask", "--app", "main", "run", "--host", "0.0.0.0"]

--- a/services/upload-service/README.md
+++ b/services/upload-service/README.md
@@ -28,17 +28,17 @@ spec:
     - name: MINIO_ROOT_USER
       value: minio
     - name: MINIO_ROOT_PASSWORD
-      value: minio123
+      value: minio1234
 EOF
 
 # allow network access
 kubectl port-forward pod/minio --address 0.0.0.0 9000 9090 -n minio-dev
 
-# Create a bucket named "knative-eventing-ai-demo-uploads"
+# Create a bucket named "ai-demo"
 python - <<EOF
 import boto3
-s3 = boto3.resource('s3', endpoint_url='http://localhost:9000', aws_access_key_id='minio', aws_secret_access_key='minio123')
-s3.create_bucket(Bucket="knative-eventing-ai-demo-uploads")
+s3 = boto3.resource('s3', endpoint_url='http://localhost:9000', aws_access_key_id='minio', aws_secret_access_key='minio1234')
+s3.create_bucket(Bucket="ai-demo")
 EOF
 ```
 
@@ -59,9 +59,9 @@ Run:
 ```shell
 S3_ENDPOINT_URL="http://localhost:9000" \
 S3_ACCESS_KEY_ID="minio" \
-S3_ACCESS_KEY_SECRET="minio123" \
+S3_ACCESS_KEY_SECRET="minio1234" \
 S3_ACCESS_SSL_VERIFY="false" \
-S3_BUCKET_NAME="knative-eventing-ai-demo-uploads" \
+S3_BUCKET_NAME="ai-demo" \
 flask --app main --debug run
 ```
 
@@ -90,9 +90,9 @@ docker run --rm \
 -p 5000:5000 \
 -e S3_ENDPOINT_URL="http://192.168.2.160:9000" \
 -e S3_ACCESS_KEY_ID="minio" \
--e S3_ACCESS_KEY_SECRET="minio123" \
+-e S3_ACCESS_KEY_SECRET="minio1234" \
 -e S3_ACCESS_SSL_VERIFY="false" \
--e S3_BUCKET_NAME="knative-eventing-ai-demo-uploads" \
+-e S3_BUCKET_NAME="ai-demo" \
 ${DOCKER_REPO_OVERRIDE}/upload-service
 ```
 

--- a/services/upload-service/README.md
+++ b/services/upload-service/README.md
@@ -87,7 +87,7 @@ docker build . -t ${DOCKER_REPO_OVERRIDE}/upload-service
 Run the image:
 ```shell
 docker run --rm \
--p 5000:5000 \
+-p 8080:8080 \
 -e S3_ENDPOINT_URL="http://192.168.2.160:9000" \
 -e S3_ACCESS_KEY_ID="minio" \
 -e S3_ACCESS_KEY_SECRET="minio1234" \
@@ -98,5 +98,5 @@ ${DOCKER_REPO_OVERRIDE}/upload-service
 
 Test the image:
 ```shell
-curl localhost:5000
+curl localhost:8080
 ```

--- a/services/upload-service/app.py
+++ b/services/upload-service/app.py
@@ -114,3 +114,7 @@ def hello_world():
     return {
         "uploadId": upload_id
     }, 200
+
+
+if __name__ == "__main__":
+    app.run(debug=True, host='0.0.0.0', port=int(os.environ.get('PORT', 8080)))

--- a/services/upload-service/main.py
+++ b/services/upload-service/main.py
@@ -1,11 +1,14 @@
-from flask import Flask, render_template, request
-from PIL import Image
 import base64
 import io
 import os
+import signal
+import sys
+import uuid
+
 import boto3
 import botocore
-import uuid
+from PIL import Image
+from flask import Flask, render_template, request
 
 MAX_IMG_SIZE_IN_BYTES = int(os.environ.get("MAX_IMG_SIZE_IN_BYTES", 1000 * 1000))
 MAX_IMG_WIDTH = int(os.environ.get("MAX_IMG_WIDTH", 640))
@@ -47,6 +50,15 @@ try:
 except Exception as e:
     print(e)
     raise Exception(f"Bucket {S3_BUCKET_NAME} does not exist")
+
+
+def handler(signal, frame):
+    print('Gracefully shutting down')
+    sys.exit(0)
+
+
+signal.signal(signal.SIGINT, handler)
+signal.signal(signal.SIGTERM, handler)
 
 
 @app.get('/')

--- a/services/upload-service/main.py
+++ b/services/upload-service/main.py
@@ -48,6 +48,7 @@ except Exception as e:
     print(e)
     raise Exception(f"Bucket {S3_BUCKET_NAME} does not exist")
 
+
 @app.get('/')
 def send_client_html():
     return render_template('index.html', max_img_width=MAX_IMG_WIDTH, max_img_height=MAX_IMG_HEIGHT)
@@ -55,6 +56,8 @@ def send_client_html():
 
 @app.post("/upload")
 def hello_world():
+    print("Received request")
+
     # set req size limit in Flask
     # https://stackoverflow.com/questions/25036498/is-it-possible-to-limit-flask-post-data-size-on-a-per-route-basis
     content_length = request.content_length

--- a/services/upload-service/main.py
+++ b/services/upload-service/main.py
@@ -14,7 +14,7 @@ MAX_IMG_HEIGHT = int(os.environ.get("MAX_IMG_HEIGHT", 640))
 S3_ENDPOINT_URL = os.environ.get("S3_ENDPOINT_URL")
 S3_ACCESS_KEY_ID = os.environ.get("S3_ACCESS_KEY_ID")
 S3_ACCESS_KEY_SECRET = os.environ.get("S3_ACCESS_KEY_SECRET")
-S3_ACCESS_SSL_VERIFY = bool(os.environ.get("S3_ACCESS_SSL_VERIFY", "true"))
+S3_ACCESS_SSL_VERIFY = os.environ.get("S3_ACCESS_SSL_VERIFY", "true").lower() == "true"
 S3_BUCKET_NAME = os.environ.get("S3_BUCKET_NAME")
 
 if not S3_ENDPOINT_URL:

--- a/services/upload-service/requirements.txt
+++ b/services/upload-service/requirements.txt
@@ -2,3 +2,4 @@ flask==2.3.2
 pillow==10.0.0
 requests==2.31.0
 boto3==1.28.48
+gunicorn==21.2.0


### PR DESCRIPTION
- Manifest for upload service that uses Ksvc to deploy on Kube
- Leverage gunicorn in Docker/Kube; use Flask devl server when running locally
- Handle SIGTERM+SIGINT